### PR TITLE
Client response muxer

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,8 @@ used to allow JVM based servers to warm-up slowly to prevent jolts in runtime pe
 
 `PB_NATS_CLIENT_SUBSCRIPTION_POOL_SIZE` - If subscription pooling is desired for the request/response cycle then the pool size maximum should be set; the pool is lazy and therefore will only start new subscriptions as necessary (default: 0)
 
+`PB_NATS_DISABLE_JNATS` - Disable the default jruby jnats client on the jruby platform, use the nats-pure.rb client instead (default: false).
+
 `PROTOBUF_NATS_CONFIG_PATH` - Custom path to the config yaml (default: "config/protobuf_nats.yml").
 
 ### YAML Config

--- a/lib/protobuf/nats.rb
+++ b/lib/protobuf/nats.rb
@@ -6,6 +6,7 @@ require "protobuf/rpc/service_directory"
 
 require "nats/io/client"
 
+require "protobuf/nats/platform"
 require "protobuf/nats/errors"
 require "protobuf/nats/client"
 require "protobuf/nats/server"
@@ -23,7 +24,7 @@ module Protobuf
       NACK = "\2".freeze
     end
 
-    NatsClient = if defined? JRUBY_VERSION
+    NatsClient = if jruby?
                    require "protobuf/nats/jnats"
                    ::Protobuf::Nats::JNats
                  else

--- a/lib/protobuf/nats/client.rb
+++ b/lib/protobuf/nats/client.rb
@@ -1,5 +1,6 @@
 require "connection_pool"
 require "protobuf/nats"
+require "protobuf/nats/platform"
 require "protobuf/rpc/connectors/base"
 require "monitor"
 
@@ -320,7 +321,7 @@ module Protobuf
       # The Java nats client offers better message queueing so we're going to use
       # that over locking ourselves. This split in code isn't great, but we can
       # refactor this later.
-      if defined? JRUBY_VERSION
+      if ::Protobuf::Nats.jruby?
 
         # This is a request that expects two responses.
         # 1. An ACK from the server. We use a shorter timeout.

--- a/lib/protobuf/nats/platform.rb
+++ b/lib/protobuf/nats/platform.rb
@@ -1,0 +1,14 @@
+module Protobuf
+  module Nats
+    def self.jruby?
+      return false if jnats_disabled?
+
+      defined? JRUBY_VERSION
+    end
+
+    def self.jnats_disabled?
+      !!ENV["PB_NATS_DISABLE_JNATS"]
+    end
+  end
+end
+

--- a/lib/protobuf/nats/server.rb
+++ b/lib/protobuf/nats/server.rb
@@ -24,7 +24,7 @@ module Protobuf
       end
 
       def queue_subscribe(name)
-        if defined? JRUBY_VERSION
+        if ::Protobuf::Nats.jruby?
           @subscriptions << @nats.subscribe(name, :queue => name) do |request_data, reply_id|
             @callback.call(request_data, reply_id)
           end
@@ -43,12 +43,12 @@ module Protobuf
       end
 
       def unsubscribe_all
-        if defined? JRUBY_VERSION
-          subscriptions.each do |subscription_id|
+        if ::Protobuf::Nats.jruby?
+          @subscriptions.each do |subscription_id|
             @nats.unsubscribe(subscription_id)
           end
         else
-          subscriptions.each { |sub| sub.unsubscribe }
+          @subscriptions.each { |sub| sub.unsubscribe }
         end
       end
     end

--- a/protobuf-nats.gemspec
+++ b/protobuf-nats.gemspec
@@ -33,7 +33,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "activesupport", ">= 3.2"
   spec.add_runtime_dependency "connection_pool"
   spec.add_runtime_dependency "protobuf", "~> 3.7", ">= 3.7.2"
-  spec.add_runtime_dependency "nats-pure", "~> 0.3", "< 0.4"
+  spec.add_runtime_dependency "nats-pure", "~> 2"
 
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "rake", "~> 10.0"

--- a/spec/fake_nats_client.rb
+++ b/spec/fake_nats_client.rb
@@ -24,9 +24,13 @@ class FakeNatsClient
   def flush
   end
 
-  def subscribe(subject, args, &block)
-    subscriptions[subject] = block
-    ::NATS::Subscription.new
+  def subscribe(subject, args = {}, &block)
+    s = ::NATS::Subscription.new
+    s.pending_queue = ::SizedQueue.new(1024)
+
+    subscriptions[subject] = {:block => block, :subscription => s }
+
+    s
   end
 
   def unsubscribe(*)
@@ -48,9 +52,15 @@ class FakeNatsClient
       Thread.new do
         begin
           sleep message.seconds_in_future
-          block = subscriptions[message.subject]
+
+          sub = subscriptions[message.subject] ||
+            subscriptions[message.subject.split(".").first + ".*"]
+
+          block = sub[:block]
           block.call(message.data) if block
           @next_message = message
+          s = sub[:subscription]
+          s.pending_queue.push(message) if s.pending_queue
         rescue => error
           puts error
         end
@@ -60,8 +70,14 @@ class FakeNatsClient
 end
 
 class FakeNackClient < FakeNatsClient
-  def subscribe(subject, args, &block)
-    Thread.new { block.call(::Protobuf::Nats::Messages::NACK) }
+  def subscribe(subject, args = {}, &block)
+    s = super
+
+    Thread.new { block.call(::Protobuf::Nats::Messages::NACK) } if block
+
+    s.pending_queue.push(NATS::Msg.new(:data => ::Protobuf::Nats::Messages::NACK, :subject => "BASE.#{@inbox}"))
+
+    s
   end
 
   def next_message(_sub, _timeout)

--- a/spec/fake_nats_client.rb
+++ b/spec/fake_nats_client.rb
@@ -26,6 +26,7 @@ class FakeNatsClient
 
   def subscribe(subject, args, &block)
     subscriptions[subject] = block
+    ::NATS::Subscription.new
   end
 
   def unsubscribe(*)

--- a/spec/protobuf/nats/jnats_spec.rb
+++ b/spec/protobuf/nats/jnats_spec.rb
@@ -1,6 +1,6 @@
 require "rspec"
 
-if defined?(JRUBY_VERSION)
+if ::Protobuf::Nats.jruby?
   require "protobuf/nats/jnats"
 
   describe ::Protobuf::Nats::JNats do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -17,6 +17,8 @@ RSpec.configure do |config|
   end
 
   config.before(:each) do
-    allow(Protobuf::Nats).to receive(:start_client_nats_connection)
+    allow(::Protobuf::Nats).to receive(:start_client_nats_connection)
+
+    ::Protobuf::Nats::Client::RESPONSE_MUXER.restart
   end
 end


### PR DESCRIPTION
This adds a single subscription response router. This means all client RPC requests will share one single subscription. This works by subscribing to `<base-uuid>.*`. Every time we send an RPC request, we store a new random `<request-uuid>` in a map, and set the reply inbox as `<base-uuid>.<request-uuid>`. Now, a single thread can pull messages from the wildcard subscription and signal to other waiting threads that their message is ready to be consumed.

There is a bit more plumbing required to make this work, but if this work successfully and fast on both jruby and MRI, we can remove our jruby specific jnats client and the custom subscription pool stuff that we added a few years back. That would be a huge win.

Old jruby client single threaded test:

```
$ PB_NATS_CLIENT_SUBSCRIPTION_POOL_SIZE=512 bx ruby -I lib bench/real_client.rb           
I, [2023-01-05T07:50:13.022476 #57405]  INFO -- : Using Protobuf::Nats::JNats to connect
Warming up --------------------------------------
single threaded performance
                         5.000  i/100ms
Calculating -------------------------------------
single threaded performance
                         26.230  (±118.2%) i/s -    110.000  in  10.732526s
```

New muxed client on jruby (not using jnats):
```
$ PB_NATS_DISABLE_JNATS=1 bx ruby -I lib bench/real_client.rb
I, [2023-01-05T07:49:17.535747 #57225]  INFO -- : Using NATS::Client to connect
Warming up --------------------------------------
single threaded performance
                        66.000  i/100ms
Calculating -------------------------------------
single threaded performance
                          3.101k (±13.4%) i/s -     30.294k in  10.007279s
```

I'm not entirely sure where the magical speedup is coming from at this point. I guess it's good to know that things appear to be working well on jruby without jnats.

MRI:

Old version:
```
$ bx ruby -I lib bench/real_client.rb             
I, [2023-01-05T07:54:14.300803 #57856]  INFO -- : Using NATS::IO::Client to connect
Warming up --------------------------------------
single threaded performance
                       304.000  i/100ms
Calculating -------------------------------------
single threaded performance
                          3.232k (± 7.8%) i/s -     32.224k in  10.074739s
```

New version:
```
$ bx ruby -I lib bench/real_client.rb
I, [2023-01-05T07:54:46.990533 #57930]  INFO -- : Using NATS::Client to connect
Warming up --------------------------------------
single threaded performance
                       294.000  i/100ms
Calculating -------------------------------------
single threaded performance
                          3.128k (±10.0%) i/s -     30.870k in  10.037075s
```

New version is reporting a little slower, but I don't think it's a substantial impact. I guess I'm more confused by the bench results than anything.

Few other things:
1. The test suite is mocked out (my fault), so there are some changes to make it work for MRI and jruby.
2. Added a new platform.rb file to make it easier to detect jruby in a single place (DRY) but also to disable the jnats loader (using the upgraded pure ruby client instead). By default there are no breaking changes.